### PR TITLE
support for Redis urls

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,17 +1,26 @@
 var redis = require('redis')
+  , parseRedisUrl = require('parse-redis-url')(redis)
   , fsPage = require('./page')
-  , synopsis = require('../client/lib/synopsis')
+  , synopsis = require('../node_modules/wiki-client/lib/synopsis')
 
 
 module.exports = function (opts) {
 
-  var database = opts.database
-    , port = database.port
-    , host = database.host
-    , options = database.options
-    , client = redis.createClient(port, host, options)
+  var options, port, host
+    , database = opts.database
     , classicPageGet = fsPage(opts).get
 
+  if (database.url) {
+    options = parseRedisUrl.parse(database.url);
+    port = options.port;
+    host = options.host;
+  } else {
+    options = database.options;
+    port = database.port;
+    host = database.host;
+  }
+
+  var client = redis.createClient(port, host, options);
 
   if (options && options.database) { 
     client.select(options.database); 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "qs": "0.6.5",
     "underscore": "*",
     "wiki-client": "*",
-    "redis": "~0.8.4"
+    "redis": "~0.8.4",
+    "parse-redis-url": "0.0.1"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
This commit keeps the existing method of configuring Redis, and adds the option to provide a url in the form `redis://dummy:password@example.com:5555/42`