### PR TITLE
Reworking Security

### DIFF
--- a/views/static.html
+++ b/views/static.html
@@ -27,16 +27,19 @@
       {{/pages}}
     </section>
     <footer class={{loginStatus}}>
-      
+
       <div id='site-owner' class='footer-item'>{{ownedBy}}</div>
 
       {{#authenticated}}
+      {{^claimed}}
+      <a href='#' class='persona-button.orange' id='claim-button'><span>{{claimBtnTxt}}</span></a>
+      {{/claimed}}
       <a href='#' class='persona-button' id='persona-logout-btn'><span>{{loginBtnTxt}}</span></a>
       {{/authenticated}}
       {{^authenticated}}
       <a href='#' class='persona-button' id='persona-login-btn'><span>{{loginBtnTxt}}</span></a>
       {{/authenticated}}
-      
+
       <span class='searchbox'>
         Search:
         <input class='search' name='search' type='text'>


### PR DESCRIPTION
**This is far from complete, and not to be pulled yet**

The code in 2c6ad47 is a first step in reworking the security. It is from a second look at this, back in March. It forms a first pass at separating the current authenticated user from the owner.

A next step would be to remove the authorization decision from the main server code - so that it would be simpler to support different access models.

Even if we don't go as far as extracting this out into a plugin, we should be able to select which form of authentication and access control we wish to use.  