### PR TITLE
changes to sitemap generation strategy

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -491,10 +491,7 @@ module.exports = exports = (argv) ->
         # log 'saved'
 
       # update sitemap
-      console.log "about to update sitemap for: " + req.params[0]
       sitemaphandler.update(req.params[0], page)
-
-
 
     # log action
 

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -22,11 +22,13 @@ module.exports = exports = (argv) ->
     undefined
 
   sitemapUpdate = (file, page, cb) ->
-    entry = {}
-    entry["slug"] = file
-    entry["title"] = page.title
-    entry["date"] = lastEdit(page.journal)
-    entry["synopsis"] = synopsis(page)
+    
+    entry = {
+      'slug': file
+      'title': page.title
+      'date': lastEdit(page.journal)
+      'synopsis': synopsis(page)
+    }
 
     slugs = sitemap.map (page) -> page.slug
 

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -1,0 +1,105 @@
+# **sitemap.coffee**
+
+fs = require 'fs'
+path = require 'path'
+events = require 'events'
+
+synopsis = require 'wiki-client/lib/synopsis'
+
+module.exports = exports = (argv) ->
+
+  sitemap = []
+
+  queue = []
+
+  sitemapLoc = path.join(argv.status, 'sitemap.json')
+
+  working = false
+
+  lastEdit = (journal) ->
+    for action in (journal || []) by -1
+      return action.date if action.date and action.type != 'fork'
+    undefined
+
+  sitemapUpdate = (file, page, cb) ->
+    entry = {}
+    entry["slug"] = file
+    entry["title"] = page.title
+    entry["date"] = lastEdit(page.journal)
+    entry["synopsis"] = synopsis(page)
+
+    slugs = sitemap.map (page) -> page.slug
+
+    idx = slugs.indexOf(file)
+
+    if ~idx
+      sitemap[idx] = entry
+    else
+      sitemap.push entry
+
+    fs.exists argv.status, (exists) ->
+      if exists
+        fs.writeFile sitemapLoc, JSON.stringify(sitemap), (e) ->
+          console.log "Error saving sitemap" if e
+      else
+        mkdirp argv.status, ->
+          fs.writeFile sitemapLoc, JSON.stringify(sitemap), (e) ->
+            console.log "Error saving sitemap" if e
+
+    cb()
+
+
+
+
+  serial = (item) ->
+    if item
+      itself.start()
+      sitemapUpdate(item.file, item.page, (e) ->
+        process.nextTick( ->
+          serial(queue.shift())
+        ))
+    else
+      itself.stop()
+
+  #### Public stuff ####
+
+  itself = new events.EventEmitter
+  itself.start = ->
+    working = true
+    @emit 'working'
+  itself.stop = ->
+    working = false
+    @emit 'finished'
+
+  itself.isWorking = ->
+    working
+
+  itself.createSitemap = (pagehandler) ->
+
+    itself.start()
+
+    pagehandler.pages (e, newsitemap) ->
+      if e
+        console.log "createSitemap: error " + e
+        return e
+      sitemap = newsitemap
+      fs.exists argv.status, (exists) ->
+        if exists
+          fs.writeFile sitemapLoc, JSON.stringify(sitemap), (e) ->
+            console.log "Error saving sitemap" if e
+
+        else
+          mkdirp argv.status, ->
+            fs.writeFile sitemapLoc, JSON.stringify(sitemap), (e) ->
+              console.log "Error saving sitemap" if e
+
+        process.nextTick ( ->
+          serial(queue.shift()))
+
+  itself.update = (file, page) ->
+    queue.push({file, page})
+    serial(queue.shift()) unless working
+
+
+
+  itself

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "optimist": "*",
     "qs": "~2.3",
     "serve-static": "^1.6.3",
-    "underscore": "*"
+    "underscore": "*",
+    "write-file-atomic": "*"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
This pull request changes the way `sitemap.json` is served. Rather than create the sitemap when requested we create it when the server is started, and update it whenever a page is created or modified.

We also save the file to `status/sitemap.json` - so we can let the server handle requests from clients that will be caching. 