### PR TITLE
changes to sitemap generation strategy (continued)

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -400,7 +400,14 @@ module.exports = exports = (argv) ->
 #
   sitemapLoc = path.join(argv.status, 'sitemap.json')
   app.get '/system/sitemap.json', cors, (req, res) ->
-    res.sendFile(sitemapLoc)
+    fs.exists sitemapLoc, (exists) ->
+      if exists
+        res.sendFile(sitemapLoc)
+      else
+        sitemaphandler.createSitemap (pagehandler)
+        # wait for the sitemap file to be written, before sending
+        sitemaphandler.once 'finished', ->
+          res.sendFile(sitemapLoc)
 
 
   app.get '/system/export.json', cors, (req, res) ->

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -404,7 +404,8 @@ module.exports = exports = (argv) ->
       if exists
         res.sendFile(sitemapLoc)
       else
-        sitemaphandler.createSitemap (pagehandler)
+        # only createSitemap if we are not already creating one
+        sitemaphandler.createSitemap (pagehandler) if !sitemaphandler.isWorking()
         # wait for the sitemap file to be written, before sending
         sitemaphandler.once 'finished', ->
           res.sendFile(sitemapLoc)

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -44,15 +44,17 @@ module.exports = exports = (argv) ->
 
     cb()
 
-  sitemapSave = (sitemap) ->
+  sitemapSave = (sitemap, cb) ->
     fs.exists argv.status, (exists) ->
       if exists
         writeFileAtomic sitemapLoc, JSON.stringify(sitemap), (e) ->
-          console.log "Error saving sitemap: " + e if e
+          return cb(e) if e
+          cb()
       else
         mkdirp argv.status, ->
           writeFileAtomic sitemapLoc, JSON.stringify(sitemap), (e) ->
-            console.log "Error saving sitemap: " + e if e
+            return cb(e) if e
+            cb()
 
 
   serial = (item) ->
@@ -64,8 +66,10 @@ module.exports = exports = (argv) ->
         )
       )
     else
-      itself.stop()
-      sitemapSave(sitemap)
+      sitemapSave sitemap, (e) ->
+        console.log "Problems saving sitemap: "+ e if e
+        itself.stop()
+
 
   #### Public stuff ####
 


### PR DESCRIPTION
continues the work started in #85, here we add:

* recreate the sitemap if `sitemap.json` has been deleted, also delay serving to client until the file has been created.
* remove sitemap from memory if not been updated for awhile - 20 minutes to start. Restores sitemap from `sitemap.json`, and recreated it if it doesn't.