### PR TITLE
fix for fedwiki/wiki-client#88

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -551,7 +551,6 @@ module.exports = exports = (argv) ->
     plugins.startServers({server: serv, argv})
     ### Sitemap ###
     # create sitemap at start-up
-    console.log "calling createSitemap"
     sitemaphandler.createSitemap(pagehandler)
 
 

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -121,6 +121,7 @@ module.exports = exports = (argv) ->
     pagehandler.pages (e, newsitemap) ->
       if e
         console.log "createSitemap: error " + e
+        itself.stop()
         return e
       sitemap = newsitemap
 
@@ -133,6 +134,7 @@ module.exports = exports = (argv) ->
       itself.start()
       sitemapRestore (e) ->
         console.log "Problems restoring sitemap: " + e if e
+        itself.createSitemap(sitemapPageHandler)
     else
       serial(queue.shift()) unless working
 


### PR DESCRIPTION
a couple of errors left the sitemap in a running state

1. If the sitemap creation fails, we signal a stop event. With a new stand-alone server, the problem will have cleared itself by the time the sitemap is first requested, other error conditions may required intervention, but by signalling a stop we allow the create to be run later.
1. When we fail to load the sitemap back into memory, probably it has been corrupted so it can't be parsed, we will recreate the sitemap.