### PR TITLE
fix for #93, and trying harder to server render story items

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -59,8 +59,11 @@ render = (page) ->
         else if story.type is 'image'
           f.div {class: "item image"},
             f.img({class: "thumbnail", src: story.url}),
-            f.p(story.text or story.caption or 'uploaded image')
-        else f.div {class: "item"}, f.p(wiki.resolveLinks(story.text or '', sanitize))
+            f.p(wiki.resolveLinks(story.text or story.caption or 'uploaded image'))
+        else if story.type is 'html'
+          f.div {class: "item html"},
+          f.p(wiki.resolveLinks(story.text or '', sanitize))
+        else f.div {class: "item"}, f.p(wiki.resolveLinks(story.text or ''))
       ).join('\n')
 
 # Set export objects for node and coffee to a function that generates a sfw server.

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -26,6 +26,7 @@ es = require 'event-stream'
 JSONStream = require 'JSONStream'
 async = require 'async'
 f = require('flates')
+sanitize = require 'sanitize-caja'
 
 # Express 4 middleware
 logger = require 'morgan'
@@ -59,7 +60,7 @@ render = (page) ->
           f.div {class: "item image"},
             f.img({class: "thumbnail", src: story.url}),
             f.p(story.text or story.caption or 'uploaded image')
-        else f.div {class: "item error"}, f.p(story.type)
+        else f.div {class: "item"}, f.p(wiki.resolveLinks(story.text or '', sanitize))
       ).join('\n')
 
 # Set export objects for node and coffee to a function that generates a sfw server.

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -54,7 +54,7 @@ render = (page) ->
     f.div {class: "story"},
       page.story.map((story) ->
         if story.type is 'paragraph'
-          f.div {class: "item paragraph"}, f.p(story.text)
+          f.div {class: "item paragraph"}, f.p(wiki.resolveLinks(story.text))
         else if story.type is 'image'
           f.div {class: "item image"},
             f.img({class: "thumbnail", src: story.url}),
@@ -290,7 +290,7 @@ module.exports = exports = (argv) ->
         pages: [
           page: file
           generated: """data-server-generated=true"""
-          story: wiki.resolveLinks(render(page))
+          story: render(page)
         ]
         user: req.session.email
         authenticated: is_authenticated(req)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "morgan": "^1.3.1",
     "optimist": "*",
     "qs": "~2.3",
+    "sanitize-caja": "*",
     "serve-static": "^1.6.3",
     "underscore": "*",
     "write-file-atomic": "*"


### PR DESCRIPTION
Rather than pass the whole page to wiki.resolveLinks, which by default will escape the pages HTML, we resolve any links in each story item.
We will also extract any text from other story types, rather than just present the story item type. Any links in this text are resolved, and the output sanitized.